### PR TITLE
Allow payment methods to be specific to a single store

### DIFF
--- a/commerce_store_gateways.module
+++ b/commerce_store_gateways.module
@@ -7,6 +7,7 @@
 
 use Drupal\commerce\BundleFieldDefinition;
 use Drupal\commerce_store\Entity\Store;
+use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -97,5 +98,25 @@ function commerce_store_gateways_entity_presave(EntityInterface $entity) {
     /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
     $store = Drupal::service('commerce_store.current_store')->getStore();
     $entity->store_id = $store;
+  }
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ * TAG = entity_query_commerce_payment_method.
+ */
+function commerce_store_gateways_query_entity_query_commerce_payment_method_alter(AlterableInterface $query) {
+  /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
+  $store = Drupal::service('commerce_store.current_store')->getStore();
+  if ($store && $query instanceof \Drupal\Core\Database\Query\SelectInterface) {
+    // Make sure that that only payment methods appropriate for the current
+    // store are shown. This is a workaround to filter the a user's list of
+    // existing payment methods.
+    // TODO: This is too generic. Find a better way to make PaymentMethodStorage::loadReusable only load payment methods appropriate for that store.
+    $query->condition(
+      $query->orConditionGroup()
+        ->condition('{commerce_payment_method}.store_id', NULL, 'is')
+        ->condition('{commerce_payment_method}.store_id', $store->id())
+    );
   }
 }

--- a/commerce_store_gateways.module
+++ b/commerce_store_gateways.module
@@ -7,6 +7,8 @@
 
 use Drupal\commerce\BundleFieldDefinition;
 use Drupal\commerce_store\Entity\Store;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -67,4 +69,21 @@ function commerce_store_gateways_get_field_definition($store_type_id) {
     ->setCardinality(BundleFieldDefinition::CARDINALITY_UNLIMITED);
 
   return $field_definition;
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function commerce_store_gateways_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  if ($entity_type->id() === 'commerce_payment_method') {
+    $fields['store_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Store'))
+      ->setDescription(t('The store with which this payment method can be used.'))
+      ->setCardinality(1)
+      ->setSetting('target_type', 'commerce_store')
+      ->setSetting('handler', 'default')
+      ->setDisplayConfigurable('view', TRUE);
+  }
+  return $fields;
 }

--- a/commerce_store_gateways.module
+++ b/commerce_store_gateways.module
@@ -7,6 +7,7 @@
 
 use Drupal\commerce\BundleFieldDefinition;
 use Drupal\commerce_store\Entity\Store;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
@@ -86,4 +87,15 @@ function commerce_store_gateways_entity_base_field_info(EntityTypeInterface $ent
       ->setDisplayConfigurable('view', TRUE);
   }
   return $fields;
+}
+
+/**
+ * Implements hook_entity_presave().
+ */
+function commerce_store_gateways_entity_presave(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() === 'commerce_payment_method' && $entity->isNew()) {
+    /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
+    $store = Drupal::service('commerce_store.current_store')->getStore();
+    $entity->store_id = $store;
+  }
 }


### PR DESCRIPTION
Here's a first attempt at making payment methods appropriate for a single store. Needs work, but is hopefully a starting point.

Summary:
1. added a `store_id` property to the `commerce_payment_method` entity.
2. added a `hook_entity_presave` for payment methods, to populate the `store_id` property with the current store.
3. added a `hook_query_TAG_alter` when fetching payment methods, to work around the fact that `PaymentMethodStorage::loadReusable` doesn't support filtering by store.